### PR TITLE
Improve login and dashboard layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Vite App</title>
+    <title>Ticket Dashboard</title>
   </head>
   <body>
     <div id="app"></div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,85 +1,9 @@
 <script setup>
-import { RouterLink, RouterView } from 'vue-router'
-import HelloWorld from './components/HelloWorld.vue'
+import { RouterView } from 'vue-router'
 </script>
 
 <template>
-  <header>
-    <img alt="Vue logo" class="logo" src="@/assets/logo.svg" width="125" height="125" />
-
-    <div class="wrapper">
-      <HelloWorld msg="You did it!" />
-
-      <nav>
-        <RouterLink to="/">Home</RouterLink>
-  
-      </nav>
-    </div>
-  </header>
-
   <RouterView />
 </template>
 
-<style scoped>
-header {
-  line-height: 1.5;
-  max-height: 100vh;
-}
-
-.logo {
-  display: block;
-  margin: 0 auto 2rem;
-}
-
-nav {
-  width: 100%;
-  font-size: 12px;
-  text-align: center;
-  margin-top: 2rem;
-}
-
-nav a.router-link-exact-active {
-  color: var(--color-text);
-}
-
-nav a.router-link-exact-active:hover {
-  background-color: transparent;
-}
-
-nav a {
-  display: inline-block;
-  padding: 0 1rem;
-  border-left: 1px solid var(--color-border);
-}
-
-nav a:first-of-type {
-  border: 0;
-}
-
-@media (min-width: 1024px) {
-  header {
-    display: flex;
-    place-items: center;
-    padding-right: calc(var(--section-gap) / 2);
-  }
-
-  .logo {
-    margin: 0 2rem 0 0;
-  }
-
-  header .wrapper {
-    display: flex;
-    place-items: flex-start;
-    flex-wrap: wrap;
-  }
-
-  nav {
-    text-align: left;
-    margin-left: -1rem;
-    font-size: 1rem;
-
-    padding: 1rem 0;
-    margin-top: 1rem;
-  }
-}
-</style>
+<style scoped></style>

--- a/src/api.js
+++ b/src/api.js
@@ -1,24 +1,24 @@
-import axios from 'axios';
+import axios from 'axios'
 
 const api = axios.create({
   baseURL: 'http://127.0.0.1:8000',
-});
+})
 
 export function login(username, password) {
-  const params = new URLSearchParams();
-  params.append('username', username);
-  params.append('password', password);
-  return api.post('/login', params);
+  const params = new URLSearchParams()
+  params.append('username', username)
+  params.append('password', password)
+  return api.post('/login', params)
 }
 
 export function getTickets(token) {
   return api.get('/tickets/', {
-    headers: { Authorization: `Bearer ${token}` }
-  });
+    headers: { Authorization: `Bearer ${token}` },
+  })
 }
 
 export function getTicket(token, id) {
   return api.get(`/tickets/${id}`, {
-    headers: { Authorization: `Bearer ${token}` }
-  });
+    headers: { Authorization: `Bearer ${token}` },
+  })
 }

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -28,8 +28,28 @@ a,
   }
 
   #app {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
+    display: flex;
     padding: 0 2rem;
   }
+}
+
+.dashboard {
+  display: flex;
+}
+
+.sidebar {
+  width: 200px;
+  padding-right: 1rem;
+}
+
+.content {
+  flex: 1;
+}
+
+.login {
+  max-width: 300px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,15 +1,23 @@
 import { createRouter, createWebHistory } from 'vue-router'
-import Login from '../views/Login.vue'
-import Tickets from '../views/Tickets.vue'
+import Login from '../views/login.vue'
+import Tickets from '../views/tickets.vue'
 
 const routes = [
   { path: '/', component: Login },
-  { path: '/tickets', component: Tickets }
+  { path: '/tickets', component: Tickets },
 ]
 
 const router = createRouter({
   history: createWebHistory(),
-  routes
+  routes,
+})
+
+router.beforeEach((to, from, next) => {
+  if (to.path !== '/' && !localStorage.getItem('token')) {
+    next('/')
+  } else {
+    next()
+  }
 })
 
 export default router

--- a/src/views/login.vue
+++ b/src/views/login.vue
@@ -20,7 +20,7 @@ async function doLogin() {
 </script>
 
 <template>
-  <div>
+  <div class="login">
     <h2>Login</h2>
     <input v-model="username" placeholder="Username" />
     <input v-model="password" type="password" placeholder="Password" />

--- a/src/views/tickets.vue
+++ b/src/views/tickets.vue
@@ -1,7 +1,9 @@
 <script setup>
 import { ref, onMounted } from 'vue'
+import { useRouter, RouterLink } from 'vue-router'
 import { getTickets } from '../api'
 
+const router = useRouter()
 const tickets = ref([])
 
 onMounted(async () => {
@@ -9,15 +11,29 @@ onMounted(async () => {
   const res = await getTickets(token)
   tickets.value = res.data
 })
+
+function logout() {
+  localStorage.removeItem('token')
+  router.push('/')
+}
 </script>
 
 <template>
-  <div>
-    <h2>Tickets</h2>
-    <ul>
-      <li v-for="ticket in tickets" :key="ticket.id">
-        {{ ticket.number }} - {{ ticket.city }} - {{ ticket.status }}
-      </li>
-    </ul>
+  <div class="dashboard">
+    <aside class="sidebar">
+      <h2>Dashboard</h2>
+      <ul>
+        <li><RouterLink to="/tickets">Tickets</RouterLink></li>
+        <li><a href="#" @click.prevent="logout">Logout</a></li>
+      </ul>
+    </aside>
+    <main class="content">
+      <h2>Tickets</h2>
+      <ul>
+        <li v-for="ticket in tickets" :key="ticket.id">
+          {{ ticket.number }} - {{ ticket.city }} - {{ ticket.status }}
+        </li>
+      </ul>
+    </main>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- route to lowercase login/tickets views
- add auth guard to router
- create a simple dashboard layout with sidebar
- style login page and dashboard
- update app template and title

## Testing
- `npm run lint` *(fails: run-s not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68761b262e9c8326bfb8a5f3e818ad18