### PR TITLE
Display ticket table with detail view

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -53,3 +53,15 @@ a,
   flex-direction: column;
   gap: 0.5rem;
 }
+
+.ticket-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.ticket-table th,
+.ticket-table td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  text-align: left;
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,10 +1,12 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import Login from '../views/login.vue'
 import Tickets from '../views/tickets.vue'
+import TicketDetail from '../views/ticketDetail.vue'
 
 const routes = [
   { path: '/', component: Login },
   { path: '/tickets', component: Tickets },
+  { path: '/tickets/:id', component: TicketDetail },
 ]
 
 const router = createRouter({

--- a/src/views/ticketDetail.vue
+++ b/src/views/ticketDetail.vue
@@ -1,0 +1,32 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { getTicket } from '../api'
+
+const route = useRoute()
+const router = useRouter()
+const ticket = ref(null)
+
+onMounted(async () => {
+  const token = localStorage.getItem('token')
+  const id = route.params.id
+  const res = await getTicket(token, id)
+  ticket.value = res.data
+})
+
+function back() {
+  router.push('/tickets')
+}
+</script>
+
+<template>
+  <div class="content" v-if="ticket">
+    <h2>Ticket Details</h2>
+    <p><strong>Number:</strong> {{ ticket.number }}</p>
+    <p><strong>City:</strong> {{ ticket.city }}</p>
+    <p><strong>Status:</strong> {{ ticket.status }}</p>
+    <img v-if="ticket.image" :src="ticket.image" alt="ticket" style="max-width: 400px" />
+    <video v-if="ticket.video" :src="ticket.video" controls style="max-width: 400px" />
+    <button @click="back">Back</button>
+  </div>
+</template>

--- a/src/views/tickets.vue
+++ b/src/views/tickets.vue
@@ -29,11 +29,26 @@ function logout() {
     </aside>
     <main class="content">
       <h2>Tickets</h2>
-      <ul>
-        <li v-for="ticket in tickets" :key="ticket.id">
-          {{ ticket.number }} - {{ ticket.city }} - {{ ticket.status }}
-        </li>
-      </ul>
+      <table class="ticket-table">
+        <thead>
+          <tr>
+            <th>Number</th>
+            <th>City</th>
+            <th>Status</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="ticket in tickets" :key="ticket.id">
+            <td>{{ ticket.number }}</td>
+            <td>{{ ticket.city }}</td>
+            <td>{{ ticket.status }}</td>
+            <td>
+              <RouterLink :to="`/tickets/${ticket.id}`">View</RouterLink>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </main>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- show ticket list in a table
- add route for viewing a single ticket
- create detail view with video and image
- style table

## Testing
- `npm run lint` *(fails: run-s not found)*

------
https://chatgpt.com/codex/tasks/task_e_687630ec93f0832683821a8b99278167