### PR TITLE
Fix ticket detail API usage

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -18,7 +18,7 @@ export function getTickets(token) {
 }
 
 export function getTicket(token, id) {
-  return api.get(`/tickets/${id}`, {
+  return api.get(`/ticket/${id}`, {
     headers: { Authorization: `Bearer ${token}` },
   })
 }


### PR DESCRIPTION
## Summary
- update API client to call `/ticket/{id}`
- fetch single ticket on ticket detail page

## Testing
- `npm run format`
- `npx prettier --write src/api.js src/views/ticketDetail.vue` *(again)*

------
https://chatgpt.com/codex/tasks/task_e_687727da793c8326a51c9f10c4b3e839