### PR TITLE
Improve sidebar behaviour

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,5 +1,18 @@
 <script setup>
 // Sidebar component reused across the app
+import { useRouter, useRoute } from 'vue-router'
+
+const router = useRouter()
+const route = useRoute()
+
+function goTickets() {
+  router.push('/tickets')
+}
+
+function logout() {
+  localStorage.removeItem('token')
+  router.push('/')
+}
 </script>
 
 <template>
@@ -7,8 +20,10 @@
     <h2>On Street Parking</h2>
     <ul>
       <li class="title">On Street Parking</li>
-      <li class="active">Tickets</li>
-      <li class="logout">Logout</li>
+      <li :class="{ active: route.path === '/tickets' }" @click="goTickets">
+        Tickets
+      </li>
+      <li class="logout" @click="logout">Logout</li>
     </ul>
   </aside>
 </template>

--- a/src/views/tickets.css
+++ b/src/views/tickets.css
@@ -3,10 +3,15 @@
   min-height: 100vh;
 }
 .sidebar {
+  position: fixed;
+  left: 0;
+  top: 0;
+  bottom: 0;
   width: 240px;
   background: #1f2937;
   color: #fff;
   padding: 1rem;
+  overflow-y: auto;
 }
 .sidebar ul {
   list-style: none;
@@ -29,6 +34,7 @@
   background: #374151;
 }
 .main {
+  margin-left: 240px;
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -121,6 +127,11 @@
     flex-direction: column;
   }
   .sidebar {
+    position: static;
     width: 100%;
+    height: auto;
+  }
+  .main {
+    margin-left: 0;
   }
 }


### PR DESCRIPTION
## Summary
- allow sidebar items to navigate and logout
- keep sidebar fixed on the left for desktop screens

## Testing
- `npm run lint` *(fails: run-s not found)*
- `npm run lint:oxlint` *(fails: oxlint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68775c98d618832689664976351983fc