### PR TITLE
Improve layout width and sticky sidebar

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,9 +1,9 @@
 @import './base.css';
 
 #app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+  width: 100%;
+  margin: 0;
+  padding: 0;
   font-weight: normal;
 }
 
@@ -23,13 +23,12 @@ a,
 
 @media (min-width: 1024px) {
   body {
-    display: flex;
-    place-items: center;
+    display: block;
   }
 
   #app {
-    display: flex;
-    padding: 0 2rem;
+    display: block;
+    padding: 0;
   }
 }
 
@@ -38,8 +37,18 @@ a,
 }
 
 .sidebar {
-  width: 200px;
+  width: 220px;
   padding-right: 1rem;
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  height: 100vh;
+  overflow-y: auto;
+}
+
+.main {
+  margin-left: 220px;
 }
 
 .content {

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -16,7 +16,7 @@ function logout() {
 </script>
 
 <template>
-  <aside class="sidebar bg-dark text-white p-3 h-100">
+  <aside class="sidebar bg-dark text-white p-3">
     <h2 class="h5">On Street Parking</h2>
     <ul class="list-unstyled mt-3">
       <li class="title fw-bold mb-2">On Street Parking</li>

--- a/src/views/tickets.css
+++ b/src/views/tickets.css
@@ -8,7 +8,12 @@
   color: #fff;
   padding: 1rem;
   overflow-y: auto;
-  min-height: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 220px;
+  height: 100vh;
 }
 .sidebar ul {
   list-style: none;
@@ -34,6 +39,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  margin-left: 220px;
 }
 .header-bar {
   display: flex;


### PR DESCRIPTION
## Summary
- expand the app container to full browser width
- stick the sidebar to the left and make it full height

## Testing
- `npm run lint` *(fails: oxlint not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a0483ae6c832688837084733fed5d