### PR TITLE
Implement next ticket API

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -41,3 +41,9 @@ export function cancelTicket(token, id) {
     },
   )
 }
+
+export function getNextTicket(token) {
+  return api.get('/ticket/next', {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}

--- a/src/views/ticketDetail.vue
+++ b/src/views/ticketDetail.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { cancelTicket, getTicket, getTickets, submitTicket } from '../api'
+import { cancelTicket, getTicket, getNextTicket, submitTicket } from '../api'
 
 import NavBar from '../components/NavBar.vue'
 import Sidebar from '../components/Sidebar.vue'
@@ -54,20 +54,16 @@ async function goToNextTicket() {
   try {
     const token = localStorage.getItem('token')
     if (token) {
-      const res = await getTickets(token)
-      const tickets = res.data
-      if (tickets.length === 0) {
+      const res = await getNextTicket(token)
+      const next = res.data
+      if (!next || !next.id) {
         router.push('/tickets')
         window.location.assign('/tickets')
         return
       }
 
-      const currentId = Number(route.params.id)
-      const idx = tickets.findIndex((t) => t.id === currentId)
-      const nextIdx = idx === -1 || idx === tickets.length - 1 ? 0 : idx + 1
-      const nextId = tickets[nextIdx].id
-      router.push(`/ticket/${nextId}`)
-      window.location.assign(`/ticket/${nextId}`)
+      router.push(`/ticket/${next.id}`)
+      window.location.assign(`/ticket/${next.id}`)
     }
   } catch (e) {
     console.error('Failed to load next ticket', e)


### PR DESCRIPTION
## Summary
- add `getNextTicket` API helper
- update ticket detail page to fetch next ticket using the new API

## Testing
- `npm run lint` *(fails: oxlint not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e041c622c8326b617d5a6358f9fb2