### PR TITLE
Update next ticket API path

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -42,8 +42,8 @@ export function cancelTicket(token, id) {
   )
 }
 
-export function getNextTicket(token) {
-  return api.get('/ticket/next', {
+export function getNextTicket(token, id) {
+  return api.get(`/ticket/${id}/next`, {
     headers: { Authorization: `Bearer ${token}` },
   })
 }

--- a/src/views/ticketDetail.vue
+++ b/src/views/ticketDetail.vue
@@ -53,8 +53,8 @@ function back() {
 async function goToNextTicket() {
   try {
     const token = localStorage.getItem('token')
-    if (token) {
-      const res = await getNextTicket(token)
+    if (token && ticket.value) {
+      const res = await getNextTicket(token, ticket.value.id)
       const next = res.data
       if (!next || !next.id) {
         router.push('/tickets')


### PR DESCRIPTION
## Summary
- update `getNextTicket` API to accept current ticket id
- use the ticket id when requesting the next ticket

## Testing
- `npm run lint` *(fails: `oxlint` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e12ac077083268be735df097da6a5