### PR TITLE
Use videojs for ticket video playback

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "axios": "^1.10.0",
     "vue": "^3.5.17",
-    "vue-router": "^4.5.1"
+    "vue-router": "^4.5.1",
+    "video.js": "^8.13.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import './assets/main.css'
+import 'video.js/dist/video-js.css'
 
 import { createApp } from 'vue'
 import App from './App.vue'


### PR DESCRIPTION
## Summary
- add video.js dependency
- load video.js styles globally
- use Video.js player in the ticket detail view

## Testing
- `npm run lint` *(fails: `oxlint` not found)*
- `npm run lint:eslint` *(fails: cannot find package 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_687f304fa7c08326aa08200ce1125796