### PR TITLE
Add paginated ticket views

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -11,8 +11,13 @@ export function login(username, password) {
   return api.post('/login', params)
 }
 
-export function getTickets(token) {
-  return api.get('/tickets?status=waiting', {
+export function getTickets(token, page = 1, pageSize = 50) {
+  const params = new URLSearchParams({
+    status: 'waiting',
+    page: String(page),
+    page_size: String(pageSize),
+  })
+  return api.get(`/tickets?${params.toString()}`, {
     headers: { Authorization: `Bearer ${token}` },
   })
 }
@@ -44,6 +49,26 @@ export function cancelTicket(token, id) {
 
 export function getNextTicket(token, id) {
   return api.get(`/ticket/${id}/next`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
+export function getSubmittedTickets(token, page = 1, pageSize = 50) {
+  const params = new URLSearchParams({
+    page: String(page),
+    page_size: String(pageSize),
+  })
+  return api.get(`/submittedtickets/?${params.toString()}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
+export function getCancelledTickets(token, page = 1, pageSize = 50) {
+  const params = new URLSearchParams({
+    page: String(page),
+    page_size: String(pageSize),
+  })
+  return api.get(`/cancelledtickets/?${params.toString()}`, {
     headers: { Authorization: `Bearer ${token}` },
   })
 }

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -9,6 +9,14 @@ function goTickets() {
   router.push('/tickets')
 }
 
+function goSubmittedTickets() {
+  router.push('/submittedtickets')
+}
+
+function goCancelledTickets() {
+  router.push('/cancelledtickets')
+}
+
 function logout() {
   localStorage.removeItem('token')
   router.push('/')
@@ -26,6 +34,20 @@ function logout() {
         @click="goTickets"
       >
         Tickets
+      </li>
+      <li
+        class="mb-1 px-2 py-1 rounded"
+        :class="{ 'bg-secondary': route.path === '/submittedtickets' }"
+        @click="goSubmittedTickets"
+      >
+        Submitted
+      </li>
+      <li
+        class="mb-1 px-2 py-1 rounded"
+        :class="{ 'bg-secondary': route.path === '/cancelledtickets' }"
+        @click="goCancelledTickets"
+      >
+        Cancelled
       </li>
       <li class="logout mt-3" @click="logout">Logout</li>
     </ul>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,11 +1,15 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import Login from '../views/login.vue'
 import Tickets from '../views/tickets.vue'
+import SubmittedTickets from '../views/submittedTickets.vue'
+import CancelledTickets from '../views/cancelledTickets.vue'
 import TicketDetail from '../views/ticketDetail.vue'
 
 const routes = [
   { path: '/', component: Login },
   { path: '/tickets', component: Tickets },
+  { path: '/submittedtickets', component: SubmittedTickets },
+  { path: '/cancelledtickets', component: CancelledTickets },
   { path: '/ticket/:id', component: TicketDetail },
 ]
 

--- a/src/views/cancelledTickets.vue
+++ b/src/views/cancelledTickets.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
-import { getTickets } from '../api'
+import { getCancelledTickets } from '../api'
 import Sidebar from '../components/Sidebar.vue'
 import NavBar from '../components/NavBar.vue'
 
@@ -15,7 +15,7 @@ async function fetchTickets(page = currentPage.value) {
   try {
     const token = localStorage.getItem('token')
     if (token) {
-      const res = await getTickets(token, page, pageSize)
+      const res = await getCancelledTickets(token, page, pageSize)
       tickets.value = res.data.map((t) => ({
         id: t.id,
         token: t.token,
@@ -92,7 +92,7 @@ function viewTicket(id) {
     <div class="dashboard px-0">
       <Sidebar />
       <div class="main">
-        <NavBar :title="'Tickets'" :notifications="tickets.length">
+        <NavBar :title="'Cancelled Tickets'" :notifications="tickets.length">
           <button class="btn primary" @click="addTicket">Add New Ticket</button>
         </NavBar>
         <div class="filters">

--- a/src/views/submittedTickets.vue
+++ b/src/views/submittedTickets.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
-import { getTickets } from '../api'
+import { getSubmittedTickets } from '../api'
 import Sidebar from '../components/Sidebar.vue'
 import NavBar from '../components/NavBar.vue'
 
@@ -15,7 +15,7 @@ async function fetchTickets(page = currentPage.value) {
   try {
     const token = localStorage.getItem('token')
     if (token) {
-      const res = await getTickets(token, page, pageSize)
+      const res = await getSubmittedTickets(token, page, pageSize)
       tickets.value = res.data.map((t) => ({
         id: t.id,
         token: t.token,
@@ -92,7 +92,7 @@ function viewTicket(id) {
     <div class="dashboard px-0">
       <Sidebar />
       <div class="main">
-        <NavBar :title="'Tickets'" :notifications="tickets.length">
+        <NavBar :title="'Submitted Tickets'" :notifications="tickets.length">
           <button class="btn primary" @click="addTicket">Add New Ticket</button>
         </NavBar>
         <div class="filters">

--- a/src/views/tickets.css
+++ b/src/views/tickets.css
@@ -124,6 +124,12 @@
 .delete {
   background: #dc3545;
 }
+.pagination {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem;
+}
 @media (max-width: 768px) {
   .dashboard {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- add pagination support to ticket list views
- create views for submitted and cancelled tickets
- update router and sidebar navigation
- extend API helpers for paginated requests

## Testing
- `npm run lint` *(fails: oxlint not found)*

------
https://chatgpt.com/codex/tasks/task_e_688743f251188326a7a941c9d51df035